### PR TITLE
Add RemoveNumbers command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,16 @@ Install as a general Vim/Neovim plugin.
 
 ## 3. Usage
 
-Execute the command.
+Execute the command to add numbers to headers.
 
 ```
 :NumberHeader
+```
+
+Execute the command to remove numbers from headers.
+
+```
+:RemoveNumbers
 ```
 
 If you want to execute the command every time on save .md automatically, write the followings in your vimrc.

--- a/denops/mnh/main.ts
+++ b/denops/mnh/main.ts
@@ -96,9 +96,31 @@ export async function main(denops: Denops): Promise<void> {
       // replace current buffer content
       await replace(denops, bufnr, contentNew);
     },
+
+    async removeNumbers() {
+      // get current header level shift
+      const currentShift = await vars.globals.get(
+        denops,
+        "mnh_header_level_shift",
+        1,
+      );
+
+      // temporarily set level shift to 99 to remove all numbers
+      await vars.globals.set(denops, "mnh_header_level_shift", 99);
+
+      // call numberHeader to remove numbers
+      await denops.dispatcher.numberHeader();
+
+      // restore original level shift
+      await vars.globals.set(denops, "mnh_header_level_shift", currentShift);
+    },
   };
 
   await denops.cmd(
     `command! -nargs=? NumberHeader call denops#request('${denops.name}', 'numberHeader', [])`,
+  );
+
+  await denops.cmd(
+    `command! -nargs=? RemoveNumbers call denops#request('${denops.name}', 'removeNumbers', [])`,
   );
 }

--- a/denops/mnh/main.ts
+++ b/denops/mnh/main.ts
@@ -105,9 +105,9 @@ export async function main(denops: Denops): Promise<void> {
         1,
       );
 
-      // set level shift to a value higher than any reasonable header depth
-      // this effectively removes all numbers since all headers will be below the shift level
-      const REMOVE_ALL_NUMBERS_SHIFT = 7; // headers only go up to h6
+      // set level shift to maximum header level
+      // this effectively removes all numbers since no header level can be greater than 6
+      const REMOVE_ALL_NUMBERS_SHIFT = 6; // h1-h6, so shift=6 means secLevel > 6 is never true
       await vars.globals.set(denops, "mnh_header_level_shift", REMOVE_ALL_NUMBERS_SHIFT);
 
       // call numberHeader to process headers with the high shift value

--- a/doc/markdown-number-header.txt
+++ b/doc/markdown-number-header.txt
@@ -20,4 +20,9 @@ NumberHeader~
 
 	Number/Renumber markdown headings.
 
+RemoveNumbers~
+	:RemoveNumbers
+
+	Remove all numbers from markdown headings.
+
 vim: ft=help tw=78 et ts=2 sw=2 sts=2 norl


### PR DESCRIPTION
## Summary

- Add RemoveNumbers command to remove numbers from Markdown headers
- Implement the feature based on the method introduced in the Qiita article
- Update documentation to include usage instructions for the new command

## Test plan

- [ ] Verify that the `:RemoveNumbers` command removes numbers from headers in Vim/Neovim
- [ ] Confirm that numbers can be added with `:NumberHeader` and then removed with `:RemoveNumbers`
- [ ] Ensure headers inside code blocks are not affected
- [ ] Verify that the `g:mnh_header_level_shift` setting value is preserved after running RemoveNumbers

Closes #4